### PR TITLE
Adding a check for the userkey attribute

### DIFF
--- a/client_with_context_test.go
+++ b/client_with_context_test.go
@@ -63,6 +63,20 @@ var TestFeature1States = []*models.FeatureState{
 				},
 			},
 			{
+				ID:    "s3.1",
+				Name:  "userkey",
+				Value: "this is for userkey prawn",
+				Attributes: []*models.StrategyAttribute{
+					{
+						ID:          "a3.1",
+						Conditional: strategies.ConditionalEquals,
+						FieldName:   strategies.FieldNameUserkey,
+						Values:      []interface{}{"prawn"},
+						Type:        strategies.TypeString,
+					},
+				},
+			},
+			{
 				ID:    "s4",
 				Name:  "version-less",
 				Value: "version less than 15.23.4",
@@ -265,6 +279,13 @@ func TestClientWithContext(t *testing.T) {
 		WithContext(&models.Context{Device: models.ContextDeviceServer}).
 		GetString("TestFeature1")
 	assert.Equal(t, "this is not for mobile users", stringValue)
+	assert.NoError(t, err)
+
+	// See if we can match the "userkey" attribute:
+	stringValue, err = testClient.
+		WithContext(&models.Context{Userkey: "prawn"}).
+		GetString("TestFeature1")
+	assert.Equal(t, "this is for userkey prawn", stringValue)
 	assert.NoError(t, err)
 
 	// See if we can match the "version-less" attribute:

--- a/pkg/models/strategies.go
+++ b/pkg/models/strategies.go
@@ -140,6 +140,19 @@ func (s Strategy) proceedWithAttributes(clientContext *Context) bool {
 			logger.Tracef("Didn't match attribute strategy (%s:%s = %v) for platform: %v\n", sa.ID, sa.FieldName, sa.Values, clientContext.Platform)
 			return false
 
+		// Match by userkey:
+		case strategies.FieldNameUserkey:
+			logger.Trace("Trying userkey")
+			matched, err := sa.matchType(sa.Values, fmt.Sprintf("%s", clientContext.Userkey))
+			if err != nil {
+				logger.WithError(err).Error("Unable to match type")
+			}
+			if matched {
+				continue
+			}
+			logger.Tracef("Didn't match attribute strategy (%s:%s = %v) for userkey: %v\n", sa.ID, sa.FieldName, sa.Values, clientContext.Userkey)
+			return false
+
 		// Match by version:
 		case strategies.FieldNameVersion:
 			logger.Trace("Trying version")

--- a/pkg/strategies/field_attributes.go
+++ b/pkg/strategies/field_attributes.go
@@ -4,5 +4,6 @@ const (
 	FieldNameCountry  = "country"
 	FieldNameDevice   = "device"
 	FieldNamePlatform = "platform"
+	FieldNameUserkey  = "userkey"
 	FieldNameVersion  = "version"
 )


### PR DESCRIPTION
This PR introduces the userkey attribute /field for the standard range of string checks. Prior to this it was only ever used to evaluate percentage-based strategies. It should solve [a recently raised issue](https://github.com/featurehub-io/featurehub-go-sdk/issues/3) too.

- [x] Added a userkey attribute check
- [x] Unit tests