### PR TITLE
Accepting any numeric value for comparisons

### DIFF
--- a/pkg/strategies/type_number.go
+++ b/pkg/strategies/type_number.go
@@ -2,6 +2,7 @@ package strategies
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // TypeNumber is for numerical values:
@@ -9,11 +10,39 @@ const TypeNumber = "NUMBER"
 
 // Number asserts the given parameters then passes on for evaluation:
 func Number(conditional string, options []interface{}, value interface{}) (bool, error) {
+	var assertedValue float64
+	var ok bool
 
-	// Type assert the value:
-	assertedValue, ok := value.(float64)
-	if !ok {
-		return false, fmt.Errorf("Unable to assert value (%v) as float64", value)
+	// Type switch on the value (because numbers can come in a bunch of interesting shapes and sizes):
+	switch value.(type) {
+	case float32:
+		assertedValue = float64(value.(float32))
+	case int:
+		assertedValue = float64(value.(int))
+	case int8:
+		assertedValue = float64(value.(int8))
+	case int16:
+		assertedValue = float64(value.(int16))
+	case int32:
+		assertedValue = float64(value.(int32))
+	case int64:
+		assertedValue = float64(value.(int64))
+	case uint:
+		assertedValue = float64(value.(uint))
+	case uint8:
+		assertedValue = float64(value.(uint8))
+	case uint16:
+		assertedValue = float64(value.(uint16))
+	case uint32:
+		assertedValue = float64(value.(uint32))
+	case uint64:
+		assertedValue = float64(value.(uint64))
+	default:
+		// In case new numeric types are invented:
+		assertedValue, ok = value.(float64)
+		if !ok {
+			return false, fmt.Errorf("Unable to assert %s value (%v) as float64", reflect.TypeOf(value), value)
+		}
 	}
 
 	// Type assert all of the options:

--- a/pkg/strategies/type_number.go
+++ b/pkg/strategies/type_number.go
@@ -15,8 +15,8 @@ func Number(conditional string, options []interface{}, value interface{}) (bool,
 
 	// Type switch on the value (because numbers can come in a bunch of interesting shapes and sizes):
 	switch value.(type) {
-	case float32:
-		assertedValue = float64(value.(float32))
+	// case float32:
+	// 	assertedValue = float64(value.(float32))
 	case int:
 		assertedValue = float64(value.(int))
 	case int8:

--- a/pkg/strategies/type_number_test.go
+++ b/pkg/strategies/type_number_test.go
@@ -1,29 +1,105 @@
 package strategies
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+type numericTest struct {
+	err     bool
+	options []interface{}
+	result  bool
+	value   interface{}
+}
+
 func TestNumberTypeAssertion(t *testing.T) {
 
-	// Try with some unsupported options values:
-	_, err := Number(ConditionalEquals, []interface{}{"string", false}, 123)
-	assert.Error(t, err)
-
-	// Try with an unsupported comparison value:
-	_, err = Number(ConditionalEquals, []interface{}{55.123}, "string")
-	assert.Error(t, err)
-
-	// Test all valid numeric types:
-	for numericValue := range []interface{}{
-		float32(44.5), float64(44.5),
-		uint(475), uint8(75), uint16(7125), uint32(712312315), uint64(7511111131232331231),
-		int(475), int8(75), int16(7125), int32(712312315), int64(7511111131232331231),
+	// Run numeric comparisons against a set of pre-defined tests and expected results:
+	for _, numericComparisonTest := range []numericTest{
+		{
+			// This will fail because we can only compare against float64 (this is how it comes with JSON from the FH API):
+			err:     true,
+			options: []interface{}{"string", false},
+			value:   123,
+		},
+		{
+			// This will fail because we can only compare numeric types (not strings):
+			err:     true,
+			options: []interface{}{55.123},
+			value:   "string",
+		},
+		{
+			// This will fail because of different floating point precision:
+			err:     true,
+			options: []interface{}{55.123},
+			result:  false,
+			value:   float32(55.123),
+		},
+		{
+			options: []interface{}{55.123},
+			result:  true,
+			value:   float64(55.123),
+		},
+		{
+			options: []interface{}{float64(55)},
+			result:  true,
+			value:   int(55),
+		},
+		{
+			options: []interface{}{float64(55)},
+			result:  true,
+			value:   int8(55),
+		},
+		{
+			options: []interface{}{float64(5555)},
+			result:  true,
+			value:   int16(5555),
+		},
+		{
+			options: []interface{}{float64(712312315)},
+			result:  true,
+			value:   int32(712312315),
+		},
+		{
+			options: []interface{}{float64(7511111131232331231)},
+			result:  true,
+			value:   int64(7511111131232331231),
+		},
+		{
+			options: []interface{}{float64(55)},
+			result:  true,
+			value:   uint(55),
+		},
+		{
+			options: []interface{}{float64(55)},
+			result:  true,
+			value:   uint8(55),
+		},
+		{
+			options: []interface{}{float64(5555)},
+			result:  true,
+			value:   uint16(5555),
+		},
+		{
+			options: []interface{}{float64(712312315)},
+			result:  true,
+			value:   uint32(712312315),
+		},
+		{
+			options: []interface{}{float64(7511111131232331231)},
+			result:  true,
+			value:   uint64(7511111131232331231),
+		},
 	} {
-		_, err = Number(ConditionalEquals, []interface{}{55.123}, numericValue)
-		assert.NoError(t, err)
+		ok, err := Number(ConditionalEquals, numericComparisonTest.options, numericComparisonTest.value)
+		assert.Equal(t, numericComparisonTest.result, ok, "Value of type %s", reflect.TypeOf(numericComparisonTest.value))
+		if numericComparisonTest.err {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
 	}
 }
 

--- a/pkg/strategies/type_number_test.go
+++ b/pkg/strategies/type_number_test.go
@@ -7,14 +7,24 @@ import (
 )
 
 func TestNumberTypeAssertion(t *testing.T) {
+
+	// Try with some unsupported options values:
 	_, err := Number(ConditionalEquals, []interface{}{"string", false}, 123)
 	assert.Error(t, err)
 
+	// Try with an unsupported comparison value:
 	_, err = Number(ConditionalEquals, []interface{}{55.123}, "string")
 	assert.Error(t, err)
 
-	_, err = Number(ConditionalEquals, []interface{}{55.123}, 44.5)
-	assert.NoError(t, err)
+	// Test all valid numeric types:
+	for numericValue := range []interface{}{
+		float32(44.5), float64(44.5),
+		uint(475), uint8(75), uint16(7125), uint32(712312315), uint64(7511111131232331231),
+		int(475), int8(75), int16(7125), int32(712312315), int64(7511111131232331231),
+	} {
+		_, err = Number(ConditionalEquals, []interface{}{55.123}, numericValue)
+		assert.NoError(t, err)
+	}
 }
 
 func TestNumberEquals(t *testing.T) {


### PR DESCRIPTION
Currently only float64 values are able to be compared when evaluating strategies for numeric types (this is because payloads coming from the FeatureHub server are JSON, and in JSON every number is a float64). This PR introduces a type-switch for all known numeric values, which saves the user from having to do this themselves. Worth mentioning that comparing float32 values with float64 doesn't work because of the difference in precision.

- [x] Doing a type-switch for numeric values for the `strategies.Number()` function
- [x] Unit tests to make sure that all known numeric types are accepted
- [x] Unit tests to ensure that comparisons are accurate with all numeric types

This is in response to an issue (https://github.com/featurehub-io/featurehub-go-sdk/issues/4) that was raised recently.