### PR TITLE
Introducing a pluggable error handler

### DIFF
--- a/pkg/streaming-client/streaming_client.go
+++ b/pkg/streaming-client/streaming_client.go
@@ -65,7 +65,7 @@ func NewStreamingClient(config *Config) (*StreamingClient, error) {
 	}
 
 	// Use the default fatalErrorFunc to handle fatal errors:
-	client.fatalErrorHandler = client.fatalErrorFunc
+	client.WithFatalErrorHandler(client.fatalErrorFunc)
 
 	// Report that we're starting:
 	logger.WithField("server_address", client.config.ServerAddress).Info("Subscribing to FeatureHub server")
@@ -120,6 +120,12 @@ func (c *StreamingClient) WithContext(context *models.Context) *ClientWithContex
 		client:  c,
 		config:  c.config,
 	}
+}
+
+// WithFatalErrorHandler configures an error handler which will be called for asynchronous fatal errors:
+func (c *StreamingClient) WithFatalErrorHandler(fatalErrorFunc ErrorFunc) *StreamingClient {
+	c.fatalErrorHandler = fatalErrorFunc
+	return c
 }
 
 // isReady triggers various notifications that the client is ready to serve data:

--- a/pkg/streaming-client/streaming_client_handlers.go
+++ b/pkg/streaming-client/streaming_client_handlers.go
@@ -42,7 +42,11 @@ func (c *StreamingClient) handleEvents() {
 
 		// Failures (from the FeatureHub server):
 		case models.FHFailure:
-			c.logger.WithError(&errors.ErrFromAPI{}).WithField("event", event.Event()).WithField("message", event.Data()).Fatal("Failure from FeatureHub server")
+			details := map[string]interface{}{
+				"event":   event.Event(),
+				"message": event.Data(),
+			}
+			c.fatalErrorHandler(&errors.ErrFromAPI{}, "Failure from FeatureHub server", details)
 
 		// One specific feature (replaces the previous version):
 		case models.FHFeature:
@@ -64,7 +68,12 @@ func (c *StreamingClient) handleSSEError(event eventsource.Event) {
 	if c.hasData {
 		c.logger.WithError(&errors.ErrFromAPI{}).WithField("event", event.Event()).WithField("message", event.Data()).Error("Error from API client")
 	} else {
-		c.logger.WithError(&errors.ErrFromAPI{}).WithField("event", event.Event()).WithField("message", event.Data()).Fatal("Error from API client")
+		// Use the fatailErrorFunc for this one:
+		details := map[string]interface{}{
+			"event":   event.Event(),
+			"message": event.Data(),
+		}
+		c.fatalErrorFunc(&errors.ErrFromAPI{}, "Error from API client", details)
 	}
 }
 


### PR DESCRIPTION
- [x] Introducing an ErrorFunc to the strealing-client package
- [x] Added a default fatalErrorFunc to the streaming client
- [x] Calling this function to deal with asynchronous fatal errors (where the user would not be able to receive an error and handle it themselves)
- [x] Allowing the user to provide their own fatalErrorHandler