### PR TITLE
Hotfix checking ip strategy

### DIFF
--- a/pkg/strategies/type_ip_address_test.go
+++ b/pkg/strategies/type_ip_address_test.go
@@ -36,6 +36,8 @@ func TestIPAddressExcludes(t *testing.T) {
 func TestIPAddressIncludes(t *testing.T) {
 	assert.False(t, evaluateIPAddress(ConditionalIncludes, []string{"10.2.0.0/24"}, "1.3.3.4/32"))
 	assert.False(t, evaluateIPAddress(ConditionalIncludes, []string{"10.0.0.0/16"}, "10.1.1.6/32"))
+	assert.False(t, evaluateIPAddress(ConditionalIncludes, []string{"10.0.0.0/16"}, "10.1.1.6"))
 	assert.True(t, evaluateIPAddress(ConditionalIncludes, []string{"10.1.0.0/16"}, "10.1.1.6/32"))
+	assert.True(t, evaluateIPAddress(ConditionalIncludes, []string{"10.1.0.0/16"}, "10.1.1.6"))
 	assert.True(t, evaluateIPAddress(ConditionalIncludes, []string{"10.1.0.0/16"}, "10.1.2.0/24"))
 }


### PR DESCRIPTION
### Problem
We have featurehub rule for ip subnet: 10.0.0.0/16, eg we should assert all ip addresses in range 10.0.0.0 - 10.0.255.255, but we always skip this rule because try to parse CIDR address and comparing strings

### Solution
We are detecting what type of ip address received, ip or ip with subnet and try to find occurrence in specified network