### PR TITLE
SSE config events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/sys v0.0.0-20221010170243-090e33056c14 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/models/config_event.go
+++ b/pkg/models/config_event.go
@@ -1,0 +1,6 @@
+package models
+
+// ConfigEvent defines model for a FeatureHub config event.
+type ConfigEvent struct {
+	EdgeStale bool `json:"edge.stale,omitempty"` // The edge server has become stale
+}

--- a/pkg/models/sse_events.go
+++ b/pkg/models/sse_events.go
@@ -12,6 +12,9 @@ const SSEBye Event = "bye"
 // SSEError is a standard SSE event (connection error):
 const SSEError Event = "error"
 
+// FHConfig is a FeatureHub config event (client configuration instructions from the server):
+const FHConfig Event = "config"
+
 // FHDeleteFeature is a FeatureHub SSE event (telling us that a feature has been deleted):
 const FHDeleteFeature Event = "delete_feature"
 

--- a/pkg/streaming-client/streaming_client.go
+++ b/pkg/streaming-client/streaming_client.go
@@ -26,6 +26,7 @@ type StreamingClient struct {
 	featuresMutex       sync.Mutex
 	featuresURL         string
 	hasData             bool
+	isRunning           bool
 	logger              *logrus.Logger
 	notifiers           notifiers
 	notifiersMutex      sync.Mutex
@@ -100,6 +101,9 @@ func (c *StreamingClient) ReadinessListener(callbackFunc func()) {
 
 // Start begins handling events from the streamer:
 func (c *StreamingClient) Start() {
+
+	// Set the isRunning flag:
+	c.isRunning = true
 
 	// Handle incoming events:
 	go c.handleEvents()

--- a/pkg/streaming-client/streaming_client_handlers.go
+++ b/pkg/streaming-client/streaming_client_handlers.go
@@ -36,6 +36,10 @@ func (c *StreamingClient) handleEvents() {
 		case models.SSEError:
 			c.handleSSEError(event)
 
+		// FeatureHub configuration events:
+		case models.FHConfig:
+			c.handleFHConfigEvent(event)
+
 		// Delete a feature from our list:
 		case models.FHDeleteFeature:
 			c.handleFHDeleteFeature(event)
@@ -74,6 +78,23 @@ func (c *StreamingClient) handleSSEError(event eventsource.Event) {
 			"message": event.Data(),
 		}
 		c.fatalErrorFunc(&errors.ErrFromAPI{}, "Error from API client", details)
+	}
+}
+
+func (c *StreamingClient) handleFHConfigEvent(event eventsource.Event) {
+
+	// Unmarshal the event payload:
+	configEvent := new(models.ConfigEvent)
+	if err := json.Unmarshal([]byte(event.Data()), configEvent); err != nil {
+		c.logger.WithError(err).WithField("event", "config").Error("Error unmarshaling SSE payload")
+	}
+
+	// Handle "edge.stale" config:
+	if configEvent.EdgeStale {
+
+		// Close the SSE client connection:
+		c.logger.Warn("The FeatureHub server has requested that we close our connection (edge.stale)! No further updates will be received - existing data will continue to be served")
+		c.apiClient.Close()
 	}
 }
 

--- a/pkg/streaming-client/streaming_client_handlers_test.go
+++ b/pkg/streaming-client/streaming_client_handlers_test.go
@@ -84,5 +84,5 @@ func TestStreamingClientHandlers(t *testing.T) {
 	assert.Contains(t, logBuffer.String(), "No registered readinessListener() to call")
 
 	// Check that the client knew not to trigger the readiness listener (because there was none):
-	assert.Contains(t, logBuffer.String(), "Cruftastic")
+	assert.Contains(t, logBuffer.String(), "The FeatureHub server has requested that we close our connection")
 }

--- a/pkg/streaming-client/streaming_client_handlers_test.go
+++ b/pkg/streaming-client/streaming_client_handlers_test.go
@@ -59,6 +59,12 @@ func TestStreamingClientHandlers(t *testing.T) {
 		event: "delete_feature",
 	}
 
+	// Load the mock apiClient up with a "config_stale" event:
+	client.apiClient.Events <- &testEvent{
+		data:  `{"edge.stale":true}`,
+		event: "config",
+	}
+
 	// Start handling events:
 	client.Start()
 
@@ -76,4 +82,7 @@ func TestStreamingClientHandlers(t *testing.T) {
 
 	// Check that the client knew not to trigger the readiness listener (because there was none):
 	assert.Contains(t, logBuffer.String(), "No registered readinessListener() to call")
+
+	// Check that the client knew not to trigger the readiness listener (because there was none):
+	assert.Contains(t, logBuffer.String(), "Cruftastic")
 }


### PR DESCRIPTION
This PR introduces support for SSE `config` events. This can be used to instruct a streaming client to disconnect from a stale edge server.